### PR TITLE
Updates to mongoose 5.1.1.  Corrects readme.md

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,12 +14,12 @@
       "name": "Felix Furtmayr"
    },
    "dependencies": {
-      "mongoose": "4.6.x",
-      "gridfs-stream": "1.1.1"
+      "gridfs-stream": "1.1.1",
+      "mongoose": "^5.1.1"
    },
    "devDependencies": {
-      "grunt": "1.0.1",
-      "grunt-eslint": "20.1.0"
+      "grunt": "^1.0.1",
+      "grunt-eslint": "^20.1.0"
    },
    "scripts": {
       "prepublish": "npm test",

--- a/readme.md
+++ b/readme.md
@@ -30,9 +30,9 @@ Idea:
 
 ```javascript
 // Start the module in the application
- var  dbConfig = require('./config.js'),  // external network file
+ var  dbConfig = require('./config.js').db,  // external network file
       mongooseMulti = require('mongoose-multi'),
-      db = mongooseMulti.start(dbConfig, './schemas.js'); // schema file path => mongoose-multi trys to require it
+      db = mongooseMulti.start(dbConfig, node.env.PWD + './schemas.js'); // schema file path => mongoose-multi trys to require it
 
  // use it
  db.application.customer.find().exec(function(err, docs) {
@@ -128,9 +128,9 @@ Option 2: For bigger projects you can have a schema file folder. Each database h
 
 ```javascript
 // Start the module
- var  dbConfig = require('./config.js'),  // external network file
+ var  dbConfig = require('./config.js').db,  // external network file
       mongooseMulti = require('mongoose-multi'),
-      db = mongooseMulti.start(dbConfig, './schemas'); // try to require all schema files within folder
+      db = mongooseMulti.start(dbConfig, node.env.PWD + './schemas'); // try to require all schema files within folder
 
 // use "db" in your app  ..
 ```


### PR DESCRIPTION
I updated the Mongoose version.

We found the readme had errors.  When you pass in a string to mongooseMulti.start it does a require that is relative to ./node_modules/mongoose-multi and can't find your path. Using mongooseMulti.start(dbConfig, node.env.PWD + './schemas.js'); corrects this issue.

Also dbConfig wants an object like:
{
         "application": 'mongodb://localhost:27017/application',
         "book": 'mongodb://localhost:27017/books'
}

Your Network config file example exports 
{
     "db":{
         "application": 'mongodb://localhost:27017/application',
         "book": 'mongodb://localhost:27017/books'
     }
 }

Either it should skip the "db": and just export the correct object or 
dbConfig = require('./config.js')
should be
dbConfig = require('./config.js').db

Thanks for the repo though.  Other than those issues it is working great.